### PR TITLE
Import ECS fields as dynamic templates

### DIFF
--- a/_dev/build/build.yml
+++ b/_dev/build/build.yml
@@ -1,3 +1,4 @@
 dependencies:
   ecs:
     reference: git@v8.9.0
+    import_mappings: true


### PR DESCRIPTION
Instead of specifying all the ECS, this imports the fields as dynamic templates. Any ECS field can be used without having to adjust the templates now.