### PR TITLE
Extend CI to install to stack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,4 +13,12 @@ jobs:
           repo: elastic/elastic-package
           tag: v0.85.0
       - name: Lint package
-        run: elastic-package check
+        run: elastic-package check -v
+      - name: Setup stack
+        run: |
+          eval "$(elastic-package stack shellinit)"
+          elastic-package stack up -d -v
+      - name: Run install
+        run: |-
+          eval "$(elastic-package stack shellinit)"
+          elastic-package install -v


### PR DESCRIPTION
This setups up the Elastic Stack and runs the install command against it to ensure package is not only validated but can also be installed.